### PR TITLE
upgrade tailwind

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,6 @@
         "plugin:react-hooks/recommended",
         "next/core-web-vitals"
     ],
-    "overrides": [],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": "latest",
@@ -27,12 +26,19 @@
             "version": "detect"
         }
     },
-    "plugins": ["react", "@typescript-eslint", "import", "prettier", "@next/eslint-plugin-next"],
+    "plugins": [
+        "react",
+        "react-refresh",
+        "import",
+        "prettier",
+        "@next/eslint-plugin-next",
+        "@typescript-eslint"
+    ],
     "rules": {
         "indent": "off",
-        "linebreak-style": ["error", "unix"],
-        "quotes": ["error", "double"],
-        "semi": ["error", "always"],
+        "no-console": "warn",
+        "quotes": "error",
+        "semi": "error",
         "import/order": [
             "error",
             {
@@ -43,12 +49,18 @@
                 "newlines-between": "always"
             }
         ],
-        "react/prop-types": "off",
-        "react/jsx-uses-react": "off",
         "react/react-in-jsx-scope": "off",
+        "react-refresh/only-export-components": "warn",
         "react-hooks/rules-of-hooks": "error",
-        "react-hooks/exhaustive-deps": "warn",
         "@typescript-eslint/no-var-requires": 0,
         "prettier/prettier": ["error", { "endOfLine": "auto" }, { "usePrettierrc": true }]
-    }
+    },
+    "overrides": [
+        {
+            "files": ["app/page.tsx"],
+            "rules": {
+                "no-console": "off"
+            }
+        }
+    ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ build
 dist
 .rpt2_cache
 .eslintcache
-tsconfig.tsbuildinfo
+tsconfig.rollup.tsbuildinfo
 
 # misc
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist
 .rpt2_cache
 .eslintcache
 tsconfig.rollup.tsbuildinfo
+*.tgz
 
 # misc
 .DS_Store

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-#npm run test
+# npm run test

--- a/.npmignore
+++ b/.npmignore
@@ -27,5 +27,6 @@ next.config.js
 npm-debug.log
 yarn-error.log
 tailwind.config.js
-postcss.config.js
-tsconfig.tsbuildinfo
+postcss.config.jstsconfig.rollup.tsbuildinfo
+tsconfig.base.json
+tsconfig.rollup.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,50 @@
 # @sciendis/react-tailwindcss-datepicker
 
+## 1.8.5 (not published yet)
+
+### Patch Changes
+
+- fix dependency array in datepicker to prevent rerenders and fix max update depth bug
+- upgrade to tailwind v4
+- add `popupClassName` prop to `Datepicker` to allow full overwrite of popover styling (copied from
+  parent repo)
+- updated eslint, rollup, prettier, tsconfig and aligned setup with parent repo (copied from parent
+  repo)## 1.8.1 (not published yet)
+
+## 1.8.4
+
+-- version bump
+
+## 1.8.3
+
+-- version bump
+
+## 1.8.2
+
+-- version bump
+
 ## 1.8.1
 
 ### Patch Changes
 
--   fix dependency array in datepicker to prevent rerenders and fix max update depth bug
+- fix dependency array in datepicker to prevent rerenders and fix max update depth bug
 
 ## 1.8.0
 
 ### Minor Changes
 
--   switch back to rollup
--   bring back explicit types
+- switch back to rollup
+- bring back explicit types
 
 ## 1.7.4 (reverted)
 
 ### Patch Changes
 
--   fix (hopefully) tsup config
--   remove type folder from dist
+- fix (hopefully) tsup config
+- remove type folder from dist
 
 ## 1.7.3
 
 ### Patch Changes
 
--   1715a0a: explicitly export types
+- 1715a0a: explicitly export types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - add `popupClassName` prop to `Datepicker` to allow full overwrite of popover styling (copied from
   parent repo)
 - updated eslint, rollup, prettier, tsconfig and aligned setup with parent repo (copied from parent
-  repo)## 1.8.1 (not published yet)
+  repo)
 
 ## 1.8.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Patch Changes
 
-- fix dependency array in datepicker to prevent rerenders and fix max update depth bug
 - upgrade to tailwind v4
 - add `popupClassName` prop to `Datepicker` to allow full overwrite of popover styling (copied from
   parent repo)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,11 @@
 Thanks for your interest in contributing to `react-tailwindcss-datepicker`! Please take a moment to
 review this document **before submitting a pull request**.
 
--   [Installation](#installation)
--   [Coding standards](#coding-standards)
--   [Running playground](#running-playgrounds)
--   [Before you make a Pull Request](#before-you-make-a-pull-request)
--   [Publish the updated Datepicker](#publish-the-updated-datepicker)
+- [Installation](#installation)
+- [Coding standards](#coding-standards)
+- [Running playground](#running-playgrounds)
+- [Before you make a Pull Request](#before-you-make-a-pull-request)
+- [Publish the updated Datepicker](#publish-the-updated-datepicker)
 
 ## Installation
 
@@ -23,7 +23,7 @@ We use `prettier` for making sure that the codebase is formatted consistently. T
 any style violations in your code, you can run:
 
 ```sh
-npm pret:fix
+npm run pret:fix
 ```
 
 ## Running playground
@@ -35,7 +35,7 @@ You can run the `dev` script and open your browser to `http://localhost:8888`.
 See complete `props` usage in `pages/index.js` file.
 
 ```sh
-npm dev
+npm run dev
 ```
 
 ## Before you make a Pull Request
@@ -46,13 +46,13 @@ Request
 **Let's clean the code first**
 
 ```sh
-npm pret:fix
+npm run pret:fix
 ```
 
 **Test a build of your changes**
 
 ```sh
-npm build
+npm run build
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <a href="https://react-tailwindcss-datepicker.vercel.app/" target="_blank">
       <img alt="React Tailwindcss Datepicker" width="100" style="border-radius: 100%;" src="https://raw.githubusercontent.com/onesine/react-tailwindcss-datepicker/master/assets/img/calendar_logo.svg?raw=true">
     </a><br><br>
-    A modern date range picker component for React using Tailwind 3 and dayjs. </br>
+    A modern date range picker component for React using Tailwind 4 and dayjs. </br>
     Forked from   <a href="https://github.com/onesine/react-tailwindcss-datepicker" target="_blank">React Tailwindcss Datepicker</a>.
 </p>
 
@@ -38,7 +38,7 @@ Go to [full documentation](https://react-tailwindcss-datepicker.vercel.app/)
 
 ## Installation
 
-⚠️ React Tailwindcss Datepicker uses Tailwind CSS 3 (with the
+⚠️ React Tailwindcss Datepicker uses Tailwind CSS 4 (with the
 [@tailwindcss/forms](https://github.com/tailwindlabs/tailwindcss-forms) plugin) &
 [Dayjs](https://day.js.org/en/) under the hood to work.
 
@@ -67,16 +67,10 @@ Make sure you have installed the peer dependencies as well with the below versio
 
 Add the datepicker to your tailwind configuration using this code
 
-```javascript
-// in your tailwind.config.js
-module.exports = {
-    // ...
-    content: [
-        "./src/**/*.{js,jsx,ts,tsx}",
-        "./node_modules/react-tailwindcss-datepicker/dist/index.esm.js"
-    ]
-    // ...
-};
+```css
+/* in your styles.css */
+@import 'tailwindcss';
+@source './node_modules/react-tailwindcss-datepicker/dist/index.esm.js';
 ```
 
 Then use react-tailwindcss-select in your app:

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-node-resolve": "^15.3.0",
         "@rollup/plugin-typescript": "^12.1.1",
-        "@tailwindcss/forms": "^0.5.3",
+        "@tailwindcss/forms": "^0.5.10",
         "@types/node": "^22.7.5",
         "@types/react": "^18.3.11",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
@@ -66,12 +66,12 @@
         "jest": "^29.7.0",
         "lint-staged": "^15.2.10",
         "next": "^14.1.2",
-        "postcss": "^8.4.19",
+        "postcss": "^8.5.6",
         "prettier": "^2.8.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rollup": "^4.24.0",
-        "tailwindcss": "^3.2.4",
+        "tailwindcss": "^4.1.16",
         "ts-jest": "^29.2.5",
         "tslib": "^2.7.0",
         "typescript": "^5.6.2"
@@ -90,5 +90,8 @@
     "homepage": "https://github.com/sciendis/react-tailwindcss-datepicker#readme",
     "files": [
         "dist"
-    ]
+    ],
+    "dependencies": {
+        "@tailwindcss/postcss": "^4.1.18"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sciendis/react-tailwindcss-datepicker",
-    "version": "1.8.1",
+    "version": "1.8.5",
     "description": " Modern date range picker component for React using Tailwind and dayjs.",
     "main": "dist/index.cjs.js",
     "module": "dist/index.esm.js",
@@ -8,19 +8,17 @@
     "author": "sciendis",
     "license": "MIT",
     "scripts": {
-        "clean": "rm -rf dist tsconfig.tsbuildinfo .rollup.cache",
-        "lint": "eslint --ignore-path .gitignore .",
-        "lint:fix": "eslint --ignore-path .gitignore --fix .",
-        "pret": "prettier -c .",
-        "pret:fix": "prettier --ignore-path .gitignore --config ./.prettierrc --write './**/*.{js,jsx,ts,tsx,css,md,json}'",
-        "code-style": "npm run pret && npm run lint",
-        "code-style:fix": "npm run pret:fix && npm run pret:fix",
-        "build": "npm run code-style && npm run clean && rollup -c rollup.config.js --bundleConfigAsCjs",
+        "watch": "rollup -c -w",
+        "clean": "rm -rf dist .rollup.cache tsconfig.rollup.tsbuildinfo",
+        "lint": "eslint .",
+        "lint:fix": "eslint --fix .",
+        "pret:fix": "prettier --write .",
+        "format": "npm run pret:fix && npm run lint:fix",
+        "build": "npm run lint && npm run clean && rollup -c rollup.config.js --bundleConfigAsCjs",
         "pub": "npm run build && npm publish",
         "dev": "next dev -p 8888",
         "test": "jest",
-        "prepare": "husky install",
-        "ci": "pnpm run lint && pnpm run test && pnpm run build"
+        "prepare": "husky"
     },
     "repository": {
         "type": "git",
@@ -45,43 +43,46 @@
     "devDependencies": {
         "@changesets/cli": "^2.27.9",
         "@jest/globals": "^29.7.0",
-        "@rollup/plugin-commonjs": "^28.0.1",
-        "@rollup/plugin-node-resolve": "^15.3.0",
-        "@rollup/plugin-typescript": "^12.1.1",
+        "@rollup/plugin-commonjs": "^28.0.2",
+        "@rollup/plugin-node-resolve": "^16.0.0",
+        "@rollup/plugin-typescript": "^12.1.2",
         "@tailwindcss/forms": "^0.5.10",
+        "@tailwindcss/postcss": "^4.1.18",
         "@types/node": "^22.7.5",
         "@types/react": "^18.3.11",
-        "@typescript-eslint/eslint-plugin": "^5.45.0",
-        "@typescript-eslint/parser": "^5.45.0",
+        "@typescript-eslint/eslint-plugin": "^8.22.0",
+        "@typescript-eslint/parser": "^8.22.0",
         "autoprefixer": "^10.4.13",
         "dayjs": "^1.11.7",
-        "eslint": "^8.29.0",
-        "eslint-config-next": "^13.1.1",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-prettier": "^4.2.1",
-        "eslint-plugin-react": "^7.31.11",
-        "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint": "^8.57.0",
+        "eslint-config-next": "^15.1.6",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-prettier": "^5.2.1",
+        "eslint-plugin-react": "^7.35.0",
+        "eslint-plugin-react-hooks": "^5.1.0",
+        "eslint-plugin-react-refresh": "^0.4.18",
         "husky": "^8.0.0",
         "jest": "^29.7.0",
         "lint-staged": "^15.2.10",
         "next": "^14.1.2",
         "postcss": "^8.5.6",
-        "prettier": "^2.8.0",
+        "prettier": "^3.3.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "rollup": "^4.24.0",
+        "rollup": "^4.34.0",
         "tailwindcss": "^4.1.16",
         "ts-jest": "^29.2.5",
-        "tslib": "^2.7.0",
+        "tslib": "^2.8.1",
         "typescript": "^5.6.2"
     },
     "lint-staged": {
         "*.{ts,tsx}": [
-            "npm run lint"
+            "eslint",
+            "prettier --write"
         ],
-        "*.{ts,tsx,css,scss,md}": [
-            "npm run pret:fix"
+        "*.{css,scss,json,md}": [
+            "prettier --write"
         ]
     },
     "bugs": {
@@ -90,8 +91,5 @@
     "homepage": "https://github.com/sciendis/react-tailwindcss-datepicker#readme",
     "files": [
         "dist"
-    ],
-    "dependencies": {
-        "@tailwindcss/postcss": "^4.1.18"
-    }
+    ]
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,3 @@
 module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {}
-    }
+    plugins: { "@tailwindcss/postcss": {} }
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,5 +19,5 @@ module.exports = {
         }
     ],
     external: ["react", "dayjs"],
-    plugins: [resolve(), commonjs(), typescript({ tsconfig: "./tsconfig.json" })]
+    plugins: [resolve(), commonjs(), typescript({ tsconfig: "./tsconfig.rollup.json" })]
 };

--- a/src/components/Calendar/Days.tsx
+++ b/src/components/Calendar/Days.tsx
@@ -320,10 +320,10 @@ const Days: React.FC<Props> = ({
                     day >= 10 ? day : "0" + day
                 }`;
 
-                if (period.start && !period.end) {
-                    dayjs(clickDay).isSame(dayHover) && continueClick();
-                } else if (!period.start && period.end) {
-                    dayjs(clickDay).isSame(dayHover) && continueClick();
+                if (period.start && !period.end && dayjs(clickDay).isSame(dayHover)) {
+                    continueClick();
+                } else if (!period.start && period.end && dayjs(clickDay).isSame(dayHover)) {
+                    continueClick();
                 } else {
                     continueClick();
                 }

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -86,11 +86,11 @@ const Calendar: React.FC<Props> = ({
     }, [current, date, previous]);
 
     const hideMonths = useCallback(() => {
-        showMonths && setShowMonths(false);
+        if (showMonths) setShowMonths(false);
     }, [showMonths]);
 
     const hideYears = useCallback(() => {
-        showYears && setShowYears(false);
+        if (showYears) setShowYears(false);
     }, [showYears]);
 
     const clickMonth = useCallback(

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -77,7 +77,7 @@ const Datepicker: React.FC<DatepickerType> = ({
         if (arrow && div && div.classList.contains("block")) {
             div.classList.remove("block");
             div.classList.remove("translate-y-0");
-            div.classList.remove("opacity-1");
+            div.classList.remove("opacity-100");
             div.classList.add("translate-y-4");
             div.classList.add("opacity-0");
             setTimeout(() => {

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -23,6 +23,7 @@ const Datepicker: React.FC<DatepickerType> = ({
     configs = undefined,
     asSingle = false,
     placeholder = null,
+    popupClassName = null,
     separator = "~",
     startFrom = new Date(),
     i18n = LANGUAGE,
@@ -236,6 +237,7 @@ const Datepicker: React.FC<DatepickerType> = ({
                 setSecondDate(nextMonth(dayjs(startFrom)));
             }
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [asSingle, startFrom?.getDate(), value]);
 
     // Variables
@@ -324,20 +326,26 @@ const Datepicker: React.FC<DatepickerType> = ({
         return typeof containerClassName === "function"
             ? containerClassName(defaultContainerClassName)
             : typeof containerClassName === "string" && containerClassName !== ""
-            ? containerClassName
-            : defaultContainerClassName;
+              ? containerClassName
+              : defaultContainerClassName;
     }, [containerClassName]);
+
+    const popupClassNameOverload = useMemo(() => {
+        const defaultPopupClassName =
+            "transition-all ease-out duration-300 absolute z-100 mt-[1px] text-sm lg:text-xs 2xl:text-sm translate-y-4 opacity-0 hidden";
+        return typeof popupClassName === "function"
+            ? popupClassName(defaultPopupClassName)
+            : typeof popupClassName === "string" && popupClassName !== ""
+              ? popupClassName
+              : defaultPopupClassName;
+    }, [popupClassName]);
 
     return (
         <DatepickerContext.Provider value={contextValues}>
             <div className={containerClassNameOverload} ref={containerRef}>
                 <Input setContextRef={setInputRef} />
 
-                <div
-                    // increase z-index so that datepicker popover is always on top
-                    className="transition-all ease-out duration-300 absolute z-50 mt-[1px] text-sm lg:text-xs 2xl:text-sm translate-y-4 opacity-0 hidden"
-                    ref={calendarContainerRef}
-                >
+                <div className={popupClassNameOverload} ref={calendarContainerRef}>
                     <Arrow ref={arrowRef} />
 
                     <div className="mt-2.5 shadow-sm border border-gray-300 px-1 py-0.5 bg-white dark:bg-slate-800 dark:text-white dark:border-slate-600 rounded-lg">

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -333,7 +333,7 @@ const Input: React.FC<Props> = (e: Props) => {
                     div.classList.remove("translate-y-4");
                     div.classList.remove("opacity-0");
                     div.classList.add("translate-y-0");
-                    div.classList.add("opacity-1");
+                    div.classList.add("opacity-100");
                 }, 1);
             }
         }

--- a/src/components/utils.tsx
+++ b/src/components/utils.tsx
@@ -118,7 +118,7 @@ export const DoubleChevronRightIcon: React.FC<IconProps> = ({ className = "w-6 h
     );
 };
 
-// eslint-disable-next-line react/display-name,@typescript-eslint/ban-types
+// eslint-disable-next-line react/display-name, @typescript-eslint/no-empty-object-type
 export const Arrow = React.forwardRef<HTMLDivElement, {}>((_props, ref) => {
     return (
         <div

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,7 @@ export interface DatepickerType {
     configs?: Configs;
     asSingle?: boolean;
     placeholder?: string;
+    popupClassName?: ClassType;
     separator?: string;
     startFrom?: Date | null;
     i18n?: string;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,1 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,1 +1,2 @@
 @import "tailwindcss";
+@plugin "tailwindcss/forms";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-    content: ["./pages/**/*.{js,ts,jsx,tsx}", "./src/**/*.{js,ts,jsx,tsx}"],
-    darkMode: "media",
-    theme: {},
-    variants: {},
-    plugins: [require("@tailwindcss/forms")]
-};

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,37 @@
+{
+    "compilerOptions": {
+        "target": "esnext",
+        "lib": ["dom", "esnext"],
+        "module": "esnext",
+        "jsx": "preserve",
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "moduleResolution": "node",
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitReturns": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "baseUrl": "src/",
+        "declaration": true,
+        "declarationDir": "./dist",
+        "outDir": "./dist",
+        "inlineSources": true,
+        "sourceMap": true,
+        "rootDir": "src",
+        "allowJs": true,
+        "plugins": [
+            {
+                "name": "next"
+            }
+        ],
+        "skipLibCheck": true,
+        "noEmit": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        // "noUncheckedIndexedAccess": true // should be enabled
+        "incremental": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "src/**/*.spec.ts", "src/**/*.test.ts", "src/**/__tests__"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,37 +1,48 @@
 {
-    "compilerOptions": {
-        "target": "esnext",
-        "lib": ["dom", "esnext"],
-        "module": "esnext",
-        "jsx": "react-jsx",
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
-        "moduleResolution": "node",
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "noImplicitReturns": true,
-        "allowSyntheticDefaultImports": true,
-        "esModuleInterop": true,
-        "baseUrl": "src/",
-        "declaration": true,
-        "declarationDir": "./dist",
-        "outDir": "./dist",
-        "inlineSources": true,
-        "sourceMap": true,
-        "rootDir": "src",
-        "allowJs": true,
-        "plugins": [
-            {
-                "name": "next"
-            }
-        ],
-        "skipLibCheck": true,
-        "noEmit": true,
-        "resolveJsonModule": true,
-        "isolatedModules": true,
-        // "noUncheckedIndexedAccess": true // should be enabled
-        "incremental": true
-    },
-    "include": ["src/**/*"],
-    "exclude": ["node_modules", "dist", "src/**/*.spec.ts", "src/**/*.test.ts", "src/**/__tests__"]
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": [
+      "dom",
+      "esnext"
+    ],
+    "module": "esnext",
+    "jsx": "preserve",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "baseUrl": "src/",
+    "declaration": true,
+    "declarationDir": "./dist",
+    "outDir": "./dist",
+    "inlineSources": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "allowJs": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    // "noUncheckedIndexedAccess": true // should be enabled
+    "incremental": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/__tests__"
+  ]
 }

--- a/tsconfig.rollup.json
+++ b/tsconfig.rollup.json
@@ -1,6 +1,6 @@
 {
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "jsx": "preserve"
+        "jsx": "react-jsx"
     }
 }


### PR DESCRIPTION
- upgrade to tailwind v4
- add `popupClassName` prop to `Datepicker` to allow full overwrite of popover styling (copied from
  parent repo)
- updated eslint, rollup, prettier, tsconfig and aligned setup with parent repo (copied from parent
  repo)
